### PR TITLE
Features/24877 load authorized scopes only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 babel.tmp.json
 builds/
 breakage/
+/.idea

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -5,6 +5,7 @@ const eslintrc = {
 	},
 	globals: {
 		SUPPORTED_LOCALES: false,
+		OVERTURE_MODULE: false,
 		BUILD_ID: false,
 		BUILD_NUMBER: false,
 	},

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -25,6 +25,7 @@ const jestConfig = {
 	globals: {
 		BUILD_ID: "000",
 		BUILD_NUMBER: "000",
+		OVERTURE_MODULE: "aModule"
 	},
 	setupFiles: [require.resolve("whatwg-fetch")],
 	setupFilesAfterEnv: [here("unexpected.js")],

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -95,6 +95,13 @@ if (locales.length) {
 	);
 }
 
+const overtureModule = pkgConf.sync("overtureModule");
+config.plugins.push(
+	new webpack.DefinePlugin({
+		OVERTURE_MODULE: JSON.stringify((overtureModule && overtureModule.name) || ""),
+	}),
+);
+
 if (parseEnv("NODE_ENV") === "production") {
 	config.devtool = "source-map";
 	config.mode = "production";


### PR DESCRIPTION
Added OVERTURE_MODULE as a global variable in order to call REST API based on the loading module.
I have tested all possibilities with the line below and it accomplishes all the need we have for this story, including the fallback to an empty string. Hope to be at your convenience.

OVERTURE_MODULE: JSON.stringify((overtureModule && overtureModule.name) || ""),