### PR TITLE
Adding tag script to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint src",
     "test": "node src test",
     "test:orc-shared": "node src buildDep https://github.com/Orckestra/orc-shared.git",
-    "watch": "node src prep && node src build --watch"
+    "watch": "node src prep && node src build --watch",
+    "tag": "node src tag"
   },
   "files": [
     "src",


### PR DESCRIPTION
Added tag script in npm scripts. So, now you can just run "npm run tag" to create new version in orc-scripts.