### PR TITLE
Fix npm build warnings

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -22,6 +22,8 @@ module.exports = {
 		require.resolve("@babel/plugin-transform-destructuring"),
 		require.resolve("@babel/plugin-proposal-object-rest-spread"),
 		require.resolve("@babel/plugin-proposal-class-properties"),
+		require.resolve("@babel/plugin-proposal-private-property-in-object"),
+		require.resolve("@babel/plugin-proposal-private-methods"),
 		[
 			"babel-plugin-root-import",
 			{


### PR DESCRIPTION
Added newly added dependencies that need the loose option to be set

The warning when doing **npm run build** is as follows (need to do a fresh install)

Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "false" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": false }]
to the "plugins" section of your Babel config.