### PR TITLE
Use --legacy-peer-deps in the build

### DIFF
--- a/.az.yml
+++ b/.az.yml
@@ -21,10 +21,19 @@ steps:
   inputs:
     versionSpec: 15.x
 
-- task: Npm@1
+- task: Npm@0
   displayName: 'npm install'
   inputs:
-    verbose: true
+    command: 'install'
+    arguments: '--legacy-peer-deps --verbose'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish eresolve-report.txt'
+  condition: failed()
+  continueOnError: true
+  inputs:
+    PathtoPublish: 'C:\npm\cache\eresolve-report.txt'
+    ArtifactName: 'NpmInstallLog'
 
 - task: Npm@1
   displayName: 'npm prune'


### PR DESCRIPTION
We have some peer dependencies that requires React 17 which causes
problem during 'npm install' because our application is built on React
16. Using the --legacy-peer-deps flag during the packages installation
works around the issue. We plan to remove this flag once we upgrade to
React 17.